### PR TITLE
[WIP] Clone depth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ end
 
 The above code will clone the [everypolitician/viewer-sinatra](https://github.com/everypolitician/viewer-sinatra) repository, checkout the given branch, in this case `new-things`, then it will run the block with the current working directory set to the repository. When the block has finished it will then commit the changes, if there are any, using the provided message and push the result back to GitHub.
 
+### Options
+
+You can pass the following options in a `Hash` as the last argument to `with_git_repo`:
+
+- `:message` (required) - The message that should be used for the commit resulting from the changes in the `with_git_repo` block.
+- `:branch` (optional) - The branch to make the changes on. This branch will be created if it doesn't already exist.
+- `:clone_depth` (optional) - An Integer representing the number of commits to clone.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/everypoliticianbot.rb
+++ b/lib/everypoliticianbot.rb
@@ -27,7 +27,7 @@ module Everypoliticianbot
       branch = options.fetch(:branch, 'master')
       message = options.fetch(:message)
       with_tmp_dir do
-        git = clone(clone_url(repo.clone_url))
+        git = clone(clone_url(repo.clone_url), depth: options[:clone_depth])
         if git.branches["origin/#{branch}"]
           git.checkout(branch)
         else
@@ -43,8 +43,8 @@ module Everypoliticianbot
 
     private
 
-    def clone(url)
-      @git ||= Git.clone(url, '.').tap do |g|
+    def clone(url, options = {})
+      @git ||= Git.clone(url, '.', options).tap do |g|
         g.config('user.name', github.login)
         g.config('user.email', github.emails.first[:email])
       end


### PR DESCRIPTION
This adds an option to limit the number of commits that are cloned by using the `--depth` option of `git commit`.

This is currently marked a `[WIP]` because it doesn't work correctly if the user specifies an _existing_ branch with the `:branch` option.
