### PR TITLE
Persist cloned repository between calls to with_git_repo

### DIFF
--- a/lib/everypoliticianbot.rb
+++ b/lib/everypoliticianbot.rb
@@ -18,6 +18,8 @@ module Everypoliticianbot
 
   # Mixin to provide a GitHub client and helpers.
   module Github
+    TMP_DIR = Dir.mktmpdir
+
     def github
       Everypoliticianbot.github
     end
@@ -27,13 +29,13 @@ module Everypoliticianbot
       branch = options.fetch(:branch, 'master')
       message = options.fetch(:message)
       with_tmp_dir do
-        git = clone(clone_url(repo.clone_url))
+        git = git_repo(clone_url(repo.clone_url), repo.name)
         if git.branches["origin/#{branch}"]
           git.checkout(branch)
         else
           git.checkout(branch, new_branch: true)
         end
-        yield
+        git.chdir { yield }
         git.add
         return unless git.status.changed.any? || git.status.added.any?
         git.commit(message)
@@ -43,8 +45,13 @@ module Everypoliticianbot
 
     private
 
-    def clone(url)
-      @git ||= Git.clone(url, '.').tap do |g|
+    def git_repo(url, destination)
+      return Git.open(destination) if File.directory?(destination)
+      clone(url, destination)
+    end
+
+    def clone(url, destination)
+      Git.clone(url, destination).tap do |g|
         g.config('user.name', github.login)
         g.config('user.email', github.emails.first[:email])
       end
@@ -58,7 +65,7 @@ module Everypoliticianbot
     end
 
     def with_tmp_dir(&block)
-      Dir.mktmpdir { |tmp_dir| Dir.chdir(tmp_dir, &block) }
+      Dir.chdir(TMP_DIR, &block)
     end
   end
 end


### PR DESCRIPTION
This change allows users to call the `with_git_repo` method multiple times in the same program without needing to clone the repo for each call.
# Thoughts while changing the code:
- I don’t like that it’s a module you include rather than a class you can instantiate
- I don’t like that it uses GitHub as well as git, since it seems like that part should be a separate gem
- I don’t like that it’s called “everypoliticianbot” (for historical reasons), because it's not really got anything to do with that.

Fixes #2 
